### PR TITLE
Make sure bridge-utils is installed

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -273,6 +273,8 @@ chmod 0440 $TEMPFILE
 sudo chown root:root $TEMPFILE
 sudo mv $TEMPFILE /etc/sudoers.d/50_stack_sh
 
+# Make sure bridge-utils is installed (for brctl)
+is_package_installed bridge-utils || install_package bridge-utils
 
 # Configure Distro Repositories
 # -----------------------------


### PR DESCRIPTION
Since the installation process needs brctl, bridge-utils must be installed. I got to this problem when installing devstack on CentOS7 so i thought i could help like this, let me know if i'm doing anything wrong.