### PR TITLE
fix the name of uwsgi from uwsgi to uWSGI

### DIFF
--- a/lib/apache
+++ b/lib/apache
@@ -118,9 +118,9 @@ function install_apache_uwsgi {
         pip_install uwsgi
         pip download uwsgi -c $REQUIREMENTS_DIR/upper-constraints.txt
         local uwsgi
-        uwsgi=$(ls uwsgi*)
+        uwsgi=$(ls uWSGI*)
         tar xvf $uwsgi
-        cd uwsgi*/apache2
+        cd ./apache2
         sudo $apxs -i -c mod_proxy_uwsgi.c
         popd
         # delete the temp directory


### PR DESCRIPTION
it produces a error message that "ls can not access 'uwsgi; No such file  or directory when using comman 'ls uwsgi'. Because package name starts with uWSGI not uwsgi.