### PR TITLE
Fix sudo su - in docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -63,7 +63,7 @@ have sudo privileges:
 .. code-block:: console
 
     $ echo "stack ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/stack
-    $ sudo su - stack
+    $ sudo -u stack -i
 
 Download DevStack
 -----------------


### PR DESCRIPTION
The sudo su is not recommended to use. For sudo it is much more convenient to use `sudo -u stack -i` to spawn interactive shell as user 'stack'