### PR TITLE
Install python bdist_wheel for devstack virtual environment

### DIFF
--- a/functions-common
+++ b/functions-common
@@ -662,11 +662,25 @@ function git_clone {
         fi
     fi
 
+    # Install python bdist_wheel for devstack virtual environment
+    install_python_bdist_wheel_for_devstack_venv
+
     # print out the results so we know what change was used in the logs
     cd $git_dest
     git show --oneline | head -1
     cd $orig_dir
 }
+
+# This funciton installs python bdist_wheel for devstack virtual environment, which is required for requirment installation
+function install_python_bdist_wheel_for_devstack_venv {
+    source /opt/stack/requirements/.venv/bin/activate
+    pushd /opt/stack/requirements
+    python setup.py bdist_wheel
+    popd
+    deactivate
+}
+
+
 
 # A variation on git clone that lets us specify a project by it's
 # actual name, like oslo.config. This is exceptionally useful in the


### PR DESCRIPTION
On Ubuntu 20.04, bdist_wheel needs to be manually install for devstack virtual environment before running stack.sh. 
Otherwise, doing stack.sh complains that building wheels for openstack-requirements fails, as show below:

Building wheels for collected packages: openstack-requirements
  Building wheel for openstack-requirements (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /opt/stack/requirements/.venv/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-wdzs2h4u/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-wdzs2h4u/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-wu_od6tp
       cwd: /tmp/pip-req-build-wdzs2h4u/
  Complete output (6 lines):
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help

  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for openstack-requirements
  Running setup.py clean for openstack-requirements
Failed to build openstack-requirements
Installing collected packages: openstack-requirements
  Attempting uninstall: openstack-requirements
    Found existing installation: openstack-requirements 1.2.1.dev4940
    Uninstalling openstack-requirements-1.2.1.dev4940:
      Successfully uninstalled openstack-requirements-1.2.1.dev4940
    Running setup.py install for openstack-requirements ... done
Successfully installed openstack-requirements-1.2.1.dev4940
