### PR TITLE
Update worlddump.py

### DIFF
--- a/tools/worlddump.py
+++ b/tools/worlddump.py
@@ -19,7 +19,7 @@
 
 import argparse
 import datetime
-from distutils import spawn
+import setuptools
 import fnmatch
 import io
 import os
@@ -76,7 +76,7 @@ def _dump_cmd(cmd):
 
 
 def _find_cmd(cmd):
-    if not spawn.find_executable(cmd):
+    if not shutil.which(cmd):
         print("*** %s not found: skipping" % cmd)
         return False
     return True


### PR DESCRIPTION
The distutils library is depreciated. According to the Python PEP 632, setuptools should be used as a substitute. I could only find one instance where a function from distutils was previously used worlddump.py (79) and replaced with the relevant substitute as mentioned in PEP 632.